### PR TITLE
Use eventemitter3 library in Node SDK

### DIFF
--- a/src/utils/batch-operate/SessionQueue.ts
+++ b/src/utils/batch-operate/SessionQueue.ts
@@ -5,7 +5,7 @@ import type {
 	BatchOperationResponse,
 	BatchOperationUrl,
 } from "./types";
-import type { EventEmitter } from "node:events";
+import type { EventEmitter } from "eventemitter3";
 import type { AirtopSessionConfigV1 } from "wrapper/AirtopSessions";
 import { distributeUrlsToBatches } from "./helpers";
 import { WindowQueue } from "./WindowQueue";

--- a/src/utils/batch-operate/WindowQueue.ts
+++ b/src/utils/batch-operate/WindowQueue.ts
@@ -5,7 +5,7 @@ import type {
 	BatchOperationResponse,
 	BatchOperationUrl,
 } from "./types";
-import type { EventEmitter } from "node:events";
+import type { EventEmitter } from "eventemitter3";
 import type { Issue } from "api";
 import { Mutex } from 'async-mutex';
 

--- a/src/utils/batch-operate/batch-util.ts
+++ b/src/utils/batch-operate/batch-util.ts
@@ -5,7 +5,7 @@ import type {
 	BatchOperationResponse,
 	BatchOperationUrl,
 } from "./types";
-import { EventEmitter } from "node:events";
+import { EventEmitter } from "eventemitter3";
 import { distributeUrlsToBatches } from "./helpers";
 import { SessionQueue } from "./SessionQueue";
 
@@ -37,9 +37,6 @@ export const batchOperate = async<T> (
 		sessionConfig,
 		onError,
 	} = config ?? {};
-
-	// Set the maximum number of listeners to accommodate all concurrent sessions and windows
-	runEmitter.setMaxListeners(maxConcurrentSessions + (maxConcurrentSessions * maxWindowsPerSession) + 1);
 
 	// Split the urls into batches
 	const initialBatches = distributeUrlsToBatches(urls, maxConcurrentSessions);


### PR DESCRIPTION
Use the `eventemitter3` library rather than `node:events` to allow running inside a browser.