### PR TITLE
Update README with latest quick start code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const client = new AirtopClient({ apiKey: "YOUR_API_KEY" });
 const session = await client.sessions.create();
 
 // use any url and prompt you like below
-const window = await client.windows.create(session.data.id, { url: "https://www.airtop.ai" });
+const window = await client.windows.create(session.data.id, { url: "https://www.wikipedia.org" });
 const contentSummary = await client.windows.pageQuery(session.data.id, window.data.windowId, {
   prompt: 'Summarize the contents of the page in 1 short paragraph up to 170 characters.',
 });

--- a/README.md
+++ b/README.md
@@ -19,8 +19,22 @@ Instantiate and use the client with the following:
 import { AirtopClient } from "@airtop/sdk";
 
 const client = new AirtopClient({ apiKey: "YOUR_API_KEY" });
-await client.windows.create("6aac6f73-bd89-4a76-ab32-5a6c422e8b0b");
+const session = await client.sessions.create();
+
+// use any url and prompt you like below
+const window = await client.windows.create(session.data.id, { url: "https://www.airtop.ai" });
+const contentSummary = await client.windows.pageQuery(session.data.id, window.data.windowId, {
+  prompt: 'Summarize the contents of the page in 1 short paragraph up to 170 characters.',
+});
+console.log(contentSummary.data.modelResponse);
+
+await client.sessions.terminate(session.data.id);
 ```
+
+Get an API key from the [Airtop Developer Portal](https://portal.airtop.ai/api-keys).
+
+See more information and examples in our [Quick Start Guide](https://docs.airtop.ai/guides/getting-started/quick-start)
+or [API Reference](https://docs.airtop.ai/api-reference/airtop-api).
 
 ## Request And Response Types
 


### PR DESCRIPTION
Great SDK repository for Airtop!

I noticed a problem when I ran the short example on the current README page. There appears to be an old placeholder id in the code?  This PR updates the example by drawing from the example on your Quick Start guide, which I tested and ran (see below). Hope it's helpful!

### OLD README 

<img width="847" alt="github-readme" src="https://github.com/user-attachments/assets/17f0b02c-a9c6-4817-bab9-6652f0188ac8" />

### NEW README

<img width="1036" alt="Screenshot 2024-12-26 at 11 43 06 AM" src="https://github.com/user-attachments/assets/4cada695-69b0-4f75-b777-ed89c108b553" />

### RUNNING THIS CODE BEFORE

<img width="1495" alt="Screenshot 2024-12-26 at 11 41 19 AM" src="https://github.com/user-attachments/assets/65b25a4c-8ef3-45c7-9133-19d0e5fe40a2" />

### RUNNING THIS CODE AFTER

<img width="1496" alt="Screenshot 2024-12-26 at 11 40 07 AM" src="https://github.com/user-attachments/assets/73eda5dd-5cda-40ea-963e-5beaa45c2f1c" />

