### PR TITLE
debug possible .fernignore problem

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -7,6 +7,6 @@ src/index.ts
 src/utils/
 .github/workflows/notify-failure.yml
 .github/workflows/ci.yml
-biome.json
-tsconfig-nobase.json
-lefthook.yml
+./biome.json
+./tsconfig-nobase.json
+./lefthook.yml


### PR DESCRIPTION
tsconfig-nobase.json is not present when fern is cloning and generating a new sdk, maybe this will help