### PR TITLE
Verify types ci and git hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           yarn install
           yarn build
+          yarn compile-nobase
           yarn biome:lint
 
   test:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,13 +11,13 @@ pre-commit:
         - "*.gen.ts"
         - "**/package-lock.json"
     "[repo] verify types":
-      run: yarn build
+      run: yarn compile-nobase
       tags:
         - verify-types
 pre-push:
   parallel: true
   commands:
     "[repo] verify types":
-      run: yarn build
+      run: yarn compile-nobase
       tags:
         - verify-types

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
         "biome:lint": "biome lint --diagnostic-level=error --no-errors-on-unmatched src",
         "biome:fix": "biome format --write && biome lint --write",
         "biome:format": "biome format --no-errors-on-unmatched --files-ignore-unknown=true",
-        "compile-nobase": "tsc --project config/tsconfig-nobase.json",
-        "prebuild": "pwd && ls -la && yarn compile-nobase"
+        "compile-nobase": "tsc --project config/tsconfig-nobase.json"
     },
     "dependencies": {
         "url-join": "4.0.1",


### PR DESCRIPTION
During CI and in git hooks, run tsc using a separate tsconfig-nobase.json to help catch some classes of bugs that `"baseUrl": "src"` can mask.  (i.e. missing a relative import)