### PR TITLE
WIP: tagging beta for release

### DIFF
--- a/.github/workflows/beta-tag.yml
+++ b/.github/workflows/beta-tag.yml
@@ -1,0 +1,21 @@
+name: beta tag
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  beta-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with: 
+          ref: beta
+        
+      - name: tag
+        run: |
+          AIRTOP_VERSION=$(jq -r .version package.json)
+          echo "AIRTOP_VERSION: $AIRTOP_VERSION"
+          # git tag "$AIRTOP_VERSION" 
+          # git push origin "$AIRTOP_VERSION"
+          # gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"

--- a/.github/workflows/beta-tag.yml
+++ b/.github/workflows/beta-tag.yml
@@ -16,6 +16,6 @@ jobs:
         run: |
           AIRTOP_VERSION=$(jq -r .version package.json)
           echo "AIRTOP_VERSION: $AIRTOP_VERSION"
-          # git tag "$AIRTOP_VERSION" 
-          # git push origin "$AIRTOP_VERSION"
-          # gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"
+          git tag "$AIRTOP_VERSION" 
+          git push origin "$AIRTOP_VERSION"
+          gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,33 @@ jobs:
           fi
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Split tag
+        env:
+          BRANCH: ${{ github.ref_name }}
+        id: split
+        run: echo "value=${{ github.ref || format('{0}{1}', 'refs/tags/', github.ref) }}" >> $GITHUB_OUTPUT
+
+      - name: 'Slack notify'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            {
+              username: 'SDK Deployer',
+              icon_emoji: ':octocat:',
+              attachments: [{
+                color: 'good',
+                blocks: [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": `Node SDK v${{ steps.split.outputs.fragment }} released 🚀`
+                    }
+                  }
+                ]
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.AIRTOP_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/temp.yml
+++ b/.github/workflows/temp.yml
@@ -1,0 +1,14 @@
+name: temp
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  temp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Split tag
+        id: split
+        run: |
+          echo "value=${{ github.ref || format('{0}{1}', 'refs/tags/', github.ref) }}"
+          echo "value=${{ github.ref || format('{0}{1}', 'refs/tags/', github.ref) }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
manually triggered workflow to create a beta tag based on whatever `beta` has for version in package.json

also move slack alert for deploy complete to this repo so it fires only when it actually worked and is complete