### PR TITLE
wait for download using all events

### DIFF
--- a/src/wrapper/AirtopSessions.ts
+++ b/src/wrapper/AirtopSessions.ts
@@ -128,7 +128,7 @@ export class AirtopSessions extends SessionsClass {
     // Create a promise that resolves to null after the timeout
     const timeoutPromise = new Promise<null>((resolve) => {
       setTimeout(() => {
-        this.log(`waitForDownload timed out after ${timeoutSeconds} seconds`);
+        this.log(`waiting for file timed out after ${timeoutSeconds} seconds`);
         resolve(null);
       }, timeoutSeconds * 1000);
     });


### PR DESCRIPTION
UPDATE:
It now defaults to `lookbackSeconds=5` when using waitForDownload, waitForDownloadStart, and downloadNextFile.  Set lookbackSeconds to 0 to disable.



old ideas:

This allows the choice between two ways of waiting for downloads:

1. Start waiting before the known event (i.e. a click) that will trigger the download:
```
    const waitPromise = client.sessions.waitForDownload({ sessionId });
    await client.windows.click(sessionId, data.windowId, { elementDescription: 'Download JSON' });
    const result = await waitPromise;
    ...
    await client.files.download(result.id, fileName);
```

2. Or start waiting after the known event, but process the entire event stream, looking for first download
```   
    await client.windows.click(sessionId, data.windowId, { elementDescription: 'Download JSON' });
    const result = await client.sessions.waitForDownload({ sessionId, includePriorEvents: true });
    ...
    await client.files.download(result.id, fileName);
```

Both have tradeoffs, though option 1 is more efficient, it is maybe not as intuitive.  Option 2 would require careful planning to make sure you are responding to the correct file event.

Naming of properties is of course open for discussion.

Went with option 3, lookback by default.